### PR TITLE
Add 'onoff' a replacement for user command 'init [0-6]'

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
+siduction-scripts (2025-10-08) unstable; urgency=medium
+
+  [ Axel Konrad ]
+  * add 'onoff' a replacement for user command 'init [0-6]'
+
 siduction-scripts (2025-02-11) unstable; urgency=medium
 
   [ Axel Konrad ]
-  * xfce desktop config moved to sttings-xfce
+  * xfce desktop config moved to settings-xfce
 
  -- Torsten Wohlfarth <towo@siduction.org>  Tue, 11 Feb 2025 14:23:20 +0100
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -24,6 +24,10 @@ Copyright: 2009      Michael Deelwater <michael.deelwater@googlemail.com>
            2011-2015 Stefan Lippers-Hollmann <s.l-h@gmx.de>
 License: GPL-2.0
 
+Files: onoff
+Copyright: 2025      Axel Konrad <axel.konrad@mailbox.org>
+License: GPL-2.0
+
 License: GPL-2.0
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/install
+++ b/debian/install
@@ -1,14 +1,16 @@
 addpkg                     usr/sbin/
 burniso	                   usr/bin/
-packages/custom.ex         usr/share/siduction-scripts/packages/
 fw                         usr/share/siduction-scripts/
 fw-data.sh                 usr/share/siduction-scripts/
 fw-detect                  usr/bin/
+live                       usr/sbin/
+onoff                      usr/sbin/
+packages/custom.ex         usr/share/siduction-scripts/packages/
 remove-nonfree             usr/sbin/
 update-resume-partition	   usr/sbin/
-live                       usr/sbin/
 wgetpaste                  usr/bin/
 xfce_icon_add_attrib.sh    usr/share/siduction-scripts/
 
 fix-xkbmap                 usr/bin
 fix-xkbmap.desktop         etc/xdg/autostart
+

--- a/onoff
+++ b/onoff
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+#
+# Name: /usr/sbin/onoff
+#
+# This script makes the functionality removed by systemd 258~rc1-1,
+# init 0 to init 6, available again to the user in a running system.
+
+if [ $# -ne 1 ]; then
+	echo "Only one option is permitted." && exit 1
+fi
+
+case  "${1}" in
+	-h|--help)
+		echo "This script makes the functionality removed by systemd 258~rc1-1,"
+		echo "init 0 to init 6, available again to the user in a running system."
+		echo "Only one digit between 0 and 6 is permitted as an option."
+	;;
+	0)
+		systemctl shutdown
+	;;
+	1)
+		systemctl isolate emergency.target
+	;;
+	2)
+		systemctl isolate rescue.target
+	;;
+	3|4)
+		systemctl isolate multi-user.target
+	;;
+	5)
+		systemctl isolate graphical.target
+	;;
+	6)
+		systemctl reboot
+	;;
+	*)
+		echo "Error: >${1}< is not a valid option" && exit 1
+	;;
+esac
+exit 0

--- a/onoff
+++ b/onoff
@@ -16,7 +16,7 @@ case  "${1}" in
 		echo "Only one digit between 0 and 6 is permitted as an option."
 	;;
 	0)
-		systemctl shutdown
+		systemctl poweroff
 	;;
 	1)
 		systemctl isolate emergency.target


### PR DESCRIPTION
Please note [siduction forum](https://forum.siduction.org/index.php?topic=9787.0)

With systemd 258~rc1-1, support for user command for runlevel and runlevel targets (init 0 to init 6) has been removed.

The change is not user-friendly from systemd and is also irrelevant in terms of the code saved.
systemd still supports the [1-5] option for the kernel line during boot.
That is why systemd blocks the "init" command with a link to ../lib/systemd/systemd

The script “onoff” in the /usr/sbin directory replace the long systemd command.
The syntax corresponds to that of init.
It also contains a short help text and a check of the option entered.